### PR TITLE
add key binding and reverse the order of the sentences

### DIFF
--- a/record.py
+++ b/record.py
@@ -342,7 +342,7 @@ def recording_proc(args: argparse.Namespace):
             record_env["AUDIODEV"] = args.device
 
         # Start recording process
-        proc = subprocess.Popen(record_cmd, stdout=subprocess.PIPE)
+        proc = subprocess.Popen(record_cmd, stdout=subprocess.PIPE, env=record_env)
         assert proc.stdout, "No stdout"
         record_wave_file = None
 

--- a/record.py
+++ b/record.py
@@ -135,7 +135,7 @@ def main():
 
     # Remaining prompt ids
     prompts_left: typing.List[str] = list(prompts.keys())
-
+    prompts_left.reverse()
     # Total number of prompts
     total_prompts: int = len(prompts_left)
 
@@ -296,7 +296,6 @@ def main():
         bottom_frame, text="Next", command=do_next, style="TButton"
     )
     next_button.pack(side="right", padx=10, pady=10)
-
     # Play back last recording button
     play_button = ttk.Button(
         bottom_frame, text="Play", command=do_play, style="TButton"
@@ -305,6 +304,12 @@ def main():
 
     do_next()
 
+    window.bind('<Return>', do_record)
+    window.bind('a', do_record)
+    window.bind('q', do_record)
+    window.bind('z', do_play)
+    window.bind('w', do_play)
+    window.bind('e', do_next)
     window.mainloop()
 
 
@@ -337,7 +342,7 @@ def recording_proc(args: argparse.Namespace):
             record_env["AUDIODEV"] = args.device
 
         # Start recording process
-        proc = subprocess.Popen(record_cmd, stdout=subprocess.PIPE, env=record_env)
+        proc = subprocess.Popen(record_cmd, stdout=subprocess.PIPE)
         assert proc.stdout, "No stdout"
         record_wave_file = None
 


### PR DESCRIPTION
This commit contains two improvements:

- I added key binding on the first 3 letters of the keyboard to 'record', 'play' and 'next'.
- I reversed the order of the sentences, so it start from the 1st sentence and not the last one (it's better when you read poem, to read them in the right order)
